### PR TITLE
Use WebWorker to compute witnesses to be compatible with larger circuits

### DIFF
--- a/src/generate_calldata.ts
+++ b/src/generate_calldata.ts
@@ -1,8 +1,7 @@
-import { create_proof } from '@noir-lang/barretenberg/dest/client_proofs';
-import setup_generic_prover from "./setup_generic_prover";
 import initAztec from "@noir-lang/aztec_backend";
 import initNoir from '@noir-lang/noir_wasm';
 import { acir_from_bytes } from '@noir-lang/noir_wasm';
+import setup_generic_prover from "./setup_generic_prover";
 
 export interface abi {
     x: number,
@@ -16,17 +15,32 @@ export async function generateCalldata(input: abi) {
     let response = await fetch('main.buf');
     let buffer = await response.arrayBuffer();
     const circuit = new Uint8Array(buffer);
-    
-    let [prover, ] = await setup_generic_prover(circuit);
 
     response = await fetch('acir.buf');
     buffer = await response.arrayBuffer();
     const bytes = new Uint8Array(buffer);
     const acir = acir_from_bytes(bytes);
-
-    console.log(acir);
     
-    const proof = await create_proof(prover, acir, input);
+    let [prover, ] = await setup_generic_prover(circuit);
+    
+    const worker = new Worker(new URL('./worker.js', import.meta.url));
+
+    const errorPromise = new Promise((resolve, reject) => {
+        worker.onerror = (e) => {
+            reject(e);
+        }
+    });
+
+    const resultPromise = new Promise((resolve, reject) => {
+        worker.onmessage = (e) => {
+            resolve(e.data);
+        }
+    });
+
+    worker.postMessage({ url: document.URL, acir, input });
+    
+    const witness: any = await Promise.race([errorPromise, resultPromise]);
+    const proof = await prover.createProof(witness);
 
     return proof;
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -7,7 +7,7 @@ onmessage = async (event) => {
     const { url, acir, input } = event.data;
 
     let values = [];
-    for (const [_, v] of Object.entries(input)) {
+    for (const [ , v] of Object.entries(input)) {
         let entry_values = AnyToHexStrs(v);
         values = values.concat(entry_values);
     }
@@ -41,7 +41,7 @@ function AnyToHexStrs(any_object) {
         let number_object = any_object;
         let number_hex = number_object.toString(16);
         // The rust code only accepts even hex digits
-        let is_even_hex_length = number_hex.length % 2 == 0;
+        let is_even_hex_length = number_hex.length % 2 === 0;
         if (is_even_hex_length) {
             values.push("0x" + number_hex)
         } else {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,58 @@
+import { compute_witnesses } from '@noir-lang/aztec_backend';
+import initAztec from "@noir-lang/aztec_backend";
+
+// Add an event listener for the message event
+onmessage = async (event) => {
+
+    const { url, acir, input } = event.data;
+
+    let values = [];
+    for (const [_, v] of Object.entries(input)) {
+        let entry_values = AnyToHexStrs(v);
+        values = values.concat(entry_values);
+    }
+
+    await initAztec(new URL('./aztec_backend_bg.wasm', url));
+
+    const witness = compute_witnesses(acir, values);
+
+    postMessage(witness);
+};
+
+function AnyToHexStrs(any_object) {
+    let values = []
+    if (Array.isArray(any_object)) {
+        for (let variable of any_object) {
+            values = values.concat(AnyToHexStrs(variable));
+        }
+    } else if (typeof any_object === 'string' || any_object instanceof String) {
+        // If the type is a string, we expect it to be a hex string
+        let string_object = any_object;
+
+        if (isValidHex(string_object)) {
+            values.push(string_object)
+        } else {
+            // TODO: throw should not be in a library, but currently we aren't doing 
+            // TODO: much in terms of error handling
+            throw new Error("strings can only be hexadecimal and must start with 0x");
+        }
+
+    } else if (Number.isInteger(any_object)) {
+        let number_object = any_object;
+        let number_hex = number_object.toString(16);
+        // The rust code only accepts even hex digits
+        let is_even_hex_length = number_hex.length % 2 == 0;
+        if (is_even_hex_length) {
+            values.push("0x" + number_hex)
+        } else {
+            values.push("0x0" + number_hex)
+        }
+    } else {
+        throw new Error("unknown object type in the abi");
+    }
+    return values
+}
+
+function isValidHex(hex_str) {
+    return !isNaN(Number(hex_str))
+}


### PR DESCRIPTION
Issue #8 points out that wasm/buffer larger than 4KB cannot be compiled in the main thread. This PR creates `worker.js` which spawns a WebWorker for the witness generation part of `generateCalldata()`.